### PR TITLE
Fixed usage of connectTypingIndicator in the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ connectTypingIndicator()(WrappedComponent: ReactClass): ReactClass
 ```javascript
 import { connectTypingIndicator } from 'layer-react';
 
-var TypingIndicatorContainer = connectTypingIndicator(TypingIndicator);
+var TypingIndicatorContainer = connectTypingIndicator()(TypingIndicator);
 ```
 
 #### Usage as ES6 Decorator
@@ -233,7 +233,7 @@ class TypingIndicator extends Component {
   }
 }
 
-export default connectTypingIndicator(TypingIndicator);
+export default connectTypingIndicator()(TypingIndicator);
 ```
 
 ## Credits


### PR DESCRIPTION
I used connectTypingIndicator without a decorator today and discovered this error in the documentation. From the source code, connectTypingIndicator is indeed a function that returns a function which takes the component.