### PR TITLE
Save callback function bound to a query to be able to unbind it later

### DIFF
--- a/src/components/connectQuery.js
+++ b/src/components/connectQuery.js
@@ -134,8 +134,7 @@ export default (getInitialQueryParams = {}, getQueries) =>
         Object.keys(this.queries).forEach((key) => {
           if (!queryBuilders[key]) {
             const query = this.queries[key];
-            const queryCallback = this.callbacks[query.internalId];
-            query.off('change', queryCallback);
+            query.off('change', this.callbacks[query.internalId]);
 
             delete this.queries[key];
             delete this.callbacks[query.internalId];
@@ -217,8 +216,7 @@ export default (getInitialQueryParams = {}, getQueries) =>
         // When the component unmounts, unsubscribe from all event listeners.
         Object.keys(this.queries).forEach((key) => {
           const query = this.queries[key];
-          const queryCallback = this.callbacks[query.internalId];
-          query.off('change', queryCallback);
+          query.off('change', this.callbacks[query.internalId]);
           this.client.off('ready', this._onClientReady, this);
         });
       }

--- a/src/components/connectQuery.js
+++ b/src/components/connectQuery.js
@@ -72,6 +72,7 @@ export default (getInitialQueryParams = {}, getQueries) =>
 
         this.client = props.client || context.client;
         this.queries = {};
+        this.callbacks = {};
 
         const queryParams = (typeof getInitialQueryParams === 'function')
           ? getInitialQueryParams(props)
@@ -133,9 +134,11 @@ export default (getInitialQueryParams = {}, getQueries) =>
         Object.keys(this.queries).forEach((key) => {
           if (!queryBuilders[key]) {
             const query = this.queries[key];
-            query.off('change', this._onQueryChange, this);
+            const queryCallback = this.callbacks[query.internalId];
+            query.off('change', queryCallback);
 
             delete this.queries[key];
+            delete this.callbacks[query.internalId];
           }
         });
 
@@ -150,10 +153,11 @@ export default (getInitialQueryParams = {}, getQueries) =>
             const newQuery = this.client.createQuery(builder);
 
             this.queries[key] = newQuery;
-
-            newQuery.on('change', () => {
+            this.callbacks[newQuery.internalId] = () => {
               this._onQueryChange(key, newQuery.data);
-            });
+            };
+
+            newQuery.on('change', this.callbacks[newQuery.internalId]);
           }
         });
 
@@ -213,7 +217,8 @@ export default (getInitialQueryParams = {}, getQueries) =>
         // When the component unmounts, unsubscribe from all event listeners.
         Object.keys(this.queries).forEach((key) => {
           const query = this.queries[key];
-          query.off('change', this._onQueryChange, this);
+          const queryCallback = this.callbacks[query.internalId];
+          query.off('change', queryCallback);
           this.client.off('ready', this._onClientReady, this);
         });
       }


### PR DESCRIPTION
When mounting/unmounting a component wrapped in by QueryContainer, I get React errors about calling setState on an unmounted component.
This seems to be due to an incorrect unbinding of callbacks on query change events.

Since we create a new function wrapping `this._onQueryChange(key, newQuery.data)`, each time, I guessed that we need to save it to be able to unbind it later otherwise it is lost.

I would be happy to receive any comments about how to do it if there's another way.