### PR TITLE
Add support for Redux

### DIFF
--- a/build/components/LayerProvider.js
+++ b/build/components/LayerProvider.js
@@ -1,0 +1,71 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _react = require('react');
+
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+/**
+ * This class uses React's childContexts to propagate the client property to all
+ * subcomponents within this component's subtree.  Subcomponents access
+ * the client property via `this.context.client`.
+ *
+ * This component expects only a single subcomponent, which in turn can have many subcomponents.
+ */
+var LayerProvider = function (_Component) {
+  _inherits(LayerProvider, _Component);
+
+  function LayerProvider(props, context) {
+    _classCallCheck(this, LayerProvider);
+
+    var _this = _possibleConstructorReturn(this, (LayerProvider.__proto__ || Object.getPrototypeOf(LayerProvider)).call(this, props, context));
+
+    _this.client = props.client;
+    return _this;
+  }
+
+  _createClass(LayerProvider, [{
+    key: 'getChildContext',
+    value: function getChildContext() {
+      return { client: this.client };
+    }
+  }, {
+    key: 'render',
+    value: function render() {
+      var children = this.props.children;
+
+
+      if (typeof children === 'function') {
+        children = children();
+      }
+
+      return _react.Children.only(children);
+    }
+  }]);
+
+  return LayerProvider;
+}(_react.Component);
+
+LayerProvider.propTypes = {
+  client: _propTypes2.default.object.isRequired,
+  children: _propTypes2.default.element
+};
+LayerProvider.childContextTypes = {
+  client: _propTypes2.default.object.isRequired
+};
+exports.default = LayerProvider;

--- a/build/components/connectQuery.js
+++ b/build/components/connectQuery.js
@@ -1,0 +1,280 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+/**
+ * Connects your Queries to your React Component properties.
+ * In the example below, a ConversationList is passed in,
+ * and a ConversationListContainer that contains a child of ConversationList
+ * and which provides ConversationList with properties provided
+ * by the queries.
+ *
+      function getInitialQueryParams (props) {
+        return {
+          paginationWindow: props.startingPaginationWindow || 100
+        };
+      }
+
+      function getQueries(props, queryParams) {
+        return {
+          conversations: QueryBuilder.conversations().paginationWindow(queryParams.paginationWindow)
+        };
+      }
+
+      var ConversationListContainer = connectQuery(getInitialQueryParams, getQueries)(ConversationList);
+ *
+ * @method connectQuery
+ * @param  {Object|Function} getInitialQueryParams   Initial properties for all queries
+ * @param  {Function} getQueries          A function that returns a hash of QueryBuilders
+ * @param {Object} getQueries.props       All properties passed in from the parent of this component
+ * @param {Object} getQueries.queryParams Initial property values as specified by getInitialQueryParams
+ * @param {Object} getQueries.return      A hash of Query instances
+ * @return {Function}                     Call this function to create a wrapped component which can be
+ *                                        be rendered and which passes query data to your component.
+ */
+exports.default = function () {
+  var getInitialQueryParams = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+  var getQueries = arguments[1];
+  return (
+    /**
+     * Takes a Component, and wraps it with a QueryContainer (makes the
+     * input Component a child Component of the QueryContainer) and
+     * passes in Query data to the wrapped Component in the form of properties.
+     * Note that the property names will match the keys returned by getQueries().
+     *
+     * @method
+     * @param  {Component} ComposedComponent   The Component to wrap
+     * @return {QueryContainer}                A Component that wraps the specified Component
+     */
+    function (ComposedComponent) {
+      var _class, _temp, _initialiseProps;
+
+      return (
+        /**
+         * A Component which manages a set of Queries and passes the output
+         * of those queries into its child component.
+         *
+         * @class QueryContainer
+         * @extends {react.Component}
+         */
+        _temp = _class = function (_Component) {
+          _inherits(QueryContainer, _Component);
+
+          /**
+           * Call getQueries to get our QueryBuilder instances, and populate
+           * state with the Query Parameters and Query Results (initially results
+           * are all [])
+           *
+           * @method constructor
+           */
+          function QueryContainer(props, context) {
+            _classCallCheck(this, QueryContainer);
+
+            var _this = _possibleConstructorReturn(this, (QueryContainer.__proto__ || Object.getPrototypeOf(QueryContainer)).call(this, props, context));
+
+            _initialiseProps.call(_this);
+
+            _this.client = props.client || context.client;
+            _this.queries = {};
+            _this.callbacks = {};
+
+            var queryParams = typeof getInitialQueryParams === 'function' ? getInitialQueryParams(props) : getInitialQueryParams;
+
+            var queryBuilders = getQueries(props, queryParams);
+
+            // Set initial queryResults to empty arrays.
+            var queryResults = Object.keys(queryBuilders).reduce(function (obj, key) {
+              return _extends({}, obj, _defineProperty({}, key, []));
+            }, {});
+
+            _this.state = {
+              queryResults: queryResults,
+              queryParams: queryParams
+            };
+            return _this;
+          }
+
+          /**
+           * On mounting (and once the client is ready) call _updateQueries
+           */
+
+
+          // Necessary in order to grab client out of the context.
+          // TODO: May want to rename to layerClient to avoid conflicts.
+
+
+          _createClass(QueryContainer, [{
+            key: 'componentWillMount',
+            value: function componentWillMount() {
+              this.client.on('ready', this._onClientReady);
+
+              if (this.client.isReady) {
+                this._updateQueries(this.props, this.state.queryParams);
+              }
+            }
+          }, {
+            key: 'componentWillReceiveProps',
+            value: function componentWillReceiveProps(nextProps) {
+              this._updateQueries(nextProps, this.state.queryParams);
+            }
+
+            /**
+             * Generate the this.queries object to contain
+             * layer.Query instances based on the getQueries()
+             * QueryBuilders.  If the query already exists, update
+             * it rather than replace it.
+             *
+             * @method _updateQueries
+             * @private
+             * @param  {Object}   props       Component properties
+             * @param  {Object}   queryParams Query properties
+             * @param  {Function} callback
+             */
+
+
+            /**
+             * Any time the Query's data changes,
+             * update this.state.queryResults[queryName]
+             * with the new results.  Setting state will cause
+             * the render method to pass the updated query data
+             * to its ComposedComponent.
+             *
+             * @method _onQueryChange
+             * @param  {string} queryName    - Name of the query (name comes from keys returned by getQueries())
+             * @param  {Object[]} newResults - Array of query results
+             */
+
+          }, {
+            key: 'render',
+
+
+            /**
+             * Pass any properties provided to the QueryContainer
+             * to its child container, along with the query results,
+             * query parameters, and a setQueryParams function.
+             *
+             * @method render
+             */
+            value: function render() {
+              var _this2 = this;
+
+              var _state = this.state,
+                  queryParams = _state.queryParams,
+                  queryResults = _state.queryResults;
+
+
+              var queryIds = {};
+              Object.keys(this.queries).forEach(function (key) {
+                queryIds[key] = _this2.queries[key].id;
+              });
+
+              var passedProps = _extends({}, queryResults, {
+                query: {
+                  queryParams: queryParams,
+                  setQueryParams: this.setQueryParams,
+                  queryIds: queryIds
+                }
+              });
+
+              return _react2.default.createElement(ComposedComponent, _extends({}, this.props, passedProps));
+            }
+          }, {
+            key: 'componentWillUnmount',
+            value: function componentWillUnmount() {
+              var _this3 = this;
+
+              // When the component unmounts, unsubscribe from all event listeners.
+              Object.keys(this.queries).forEach(function (key) {
+                var query = _this3.queries[key];
+                query.off('change', _this3.callbacks[query.internalId]);
+                _this3.client.off('ready', _this3._onClientReady, _this3);
+              });
+            }
+          }]);
+
+          return QueryContainer;
+        }(_react.Component), _class.propTypes = {
+          client: _propTypes2.default.object }, _class.contextTypes = {
+          client: _propTypes2.default.object }, _initialiseProps = function _initialiseProps() {
+          var _this4 = this;
+
+          this._onClientReady = function () {
+            _this4._updateQueries(_this4.props, _this4.state.queryParams);
+          };
+
+          this.setQueryParams = function (nextQueryParams, callback) {
+            _this4._updateQueries(_this4.props, nextQueryParams, callback);
+          };
+
+          this._updateQueries = function (props, queryParams, callback) {
+            var queryBuilders = getQueries(props, queryParams);
+
+            // Remove any queries that no longer exist
+            Object.keys(_this4.queries).forEach(function (key) {
+              if (!queryBuilders[key]) {
+                var query = _this4.queries[key];
+                query.off('change', _this4.callbacks[query.internalId]);
+
+                delete _this4.queries[key];
+                delete _this4.callbacks[query.internalId];
+              }
+            });
+
+            // Update existing queries / Create new queries
+            Object.keys(queryBuilders).forEach(function (key) {
+              var query = _this4.queries[key];
+              var builder = queryBuilders[key];
+
+              if (query) {
+                query.update(builder.build());
+              } else {
+                var newQuery = _this4.client.createQuery(builder);
+
+                _this4.queries[key] = newQuery;
+                _this4.callbacks[newQuery.internalId] = function () {
+                  _this4._onQueryChange(key, newQuery.data);
+                };
+
+                newQuery.on('change', _this4.callbacks[newQuery.internalId]);
+              }
+            });
+
+            _this4.setState({
+              queryParams: queryParams
+            }, callback);
+          };
+
+          this._onQueryChange = function (queryName, newResults) {
+            _this4.setState({
+              queryResults: _extends({}, _this4.state.queryResults, _defineProperty({}, queryName, newResults))
+            });
+          };
+        }, _temp
+      );
+    }
+  );
+};

--- a/build/components/connectQueryParent.js
+++ b/build/components/connectQueryParent.js
@@ -1,0 +1,194 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _react = require('react');
+
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+/**
+ * Provides base Layer query functionality.
+ * Intended to be subclassed, does not provide a Render method.
+ * Built to abstract functionality to a higher level, so different
+ * store implementations can be used (see connectQuery and connectReduxQuery).
+ * See below for an example usage.
+ *
+      class QueryContainer extends connectQueryParent(getInitialQueryParams, getQueries)
+ *
+ * @method connectQuery
+ * @param  {Object|Function} getInitialQueryParams   Initial properties for all queries
+ * @param  {Function} getQueries          A function that returns a hash of QueryBuilders
+ * @param {Object} getQueries.props       All properties passed in from the parent of this component
+ * @param {Object} getQueries.queryParams Initial property values as specified by getInitialQueryParams
+ * @param {Object} getQueries.return      A hash of Query instances
+ * @return {Function}                     Call this function to create a parent component to extend Query
+ *                                        subclasses
+ */
+exports.default = function () {
+  var _class, _temp, _initialiseProps;
+
+  var getInitialQueryParams = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+  var getQueries = arguments[1];
+  return (
+    /**
+     * A Component which manages a set of Queries and passes the output
+     * of those queries into its child component.
+     *
+     * @class QueryContainer
+     * @extends {react.Component}
+     */
+    _temp = _class = function (_Component) {
+      _inherits(Query, _Component);
+
+      /**
+       * Call getQueries to get our QueryBuilder instances, and populate
+       * state with the Query Parameters and Query Results (initially results
+       * are all [])
+       *
+       * @method constructor
+       */
+      function Query(props, context) {
+        _classCallCheck(this, Query);
+
+        var _this = _possibleConstructorReturn(this, (Query.__proto__ || Object.getPrototypeOf(Query)).call(this, props, context));
+
+        _initialiseProps.call(_this);
+
+        _this.client = props.client || context.client;
+        _this.queries = {};
+        _this.callbacks = {};
+
+        _this.queryParams = typeof getInitialQueryParams === 'function' ? getInitialQueryParams(props) : getInitialQueryParams;
+
+        _this.queryBuilders = getQueries(props, _this.queryParams);
+
+        // Set initial queryResults to empty arrays.
+        _this.queryResults = Object.keys(_this.queryBuilders).reduce(function (obj, key) {
+          return _extends({}, obj, _defineProperty({}, key, []));
+        }, {});
+        return _this;
+      }
+
+      /**
+       * On mounting (and once the client is ready) call _updateQueries
+       */
+
+
+      // Necessary in order to grab client out of the context.
+      // TODO: May want to rename to layerClient to avoid conflicts.
+
+
+      _createClass(Query, [{
+        key: 'componentWillMount',
+        value: function componentWillMount() {
+          this.client.on('ready', this._onClientReady);
+
+          if (this.client.isReady) {
+            this._updateQueries(this.props, this.state.queryParams);
+          }
+        }
+      }, {
+        key: 'componentWillReceiveProps',
+        value: function componentWillReceiveProps(nextProps) {
+          this._updateQueries(nextProps, this.state.queryParams);
+        }
+
+        /**
+         * Generate the this.queries object to contain
+         * layer.Query instances based on the getQueries()
+         * QueryBuilders.  If the query already exists, update
+         * it rather than replace it.
+         *
+         * @method _updateQueries
+         * @private
+         * @param  {Object}   props       Component properties
+         * @param  {Object}   queryParams Query properties
+         * @param  {Function} callback
+         */
+
+      }, {
+        key: 'componentWillUnmount',
+        value: function componentWillUnmount() {
+          var _this2 = this;
+
+          // When the component unmounts, unsubscribe from all event listeners.
+          Object.keys(this.queries).forEach(function (key) {
+            var query = _this2.queries[key];
+            query.off('change', _this2.callbacks[query.internalId]);
+            _this2.client.off('ready', _this2._onClientReady, _this2);
+          });
+        }
+      }]);
+
+      return Query;
+    }(_react.Component), _class.propTypes = {
+      client: _propTypes2.default.object }, _class.contextTypes = {
+      client: _propTypes2.default.object }, _initialiseProps = function _initialiseProps() {
+      var _this3 = this;
+
+      this._onClientReady = function () {
+        _this3._updateQueries(_this3.props, _this3.state.queryParams);
+      };
+
+      this.setQueryParams = function (nextQueryParams, callback) {
+        _this3._updateQueries(_this3.props, nextQueryParams, callback);
+      };
+
+      this._updateQueries = function (props, queryParams, callback) {
+        var queryBuilders = getQueries(props, queryParams);
+
+        // Remove any queries that no longer exist
+        Object.keys(_this3.queries).forEach(function (key) {
+          if (!queryBuilders[key]) {
+            var query = _this3.queries[key];
+            query.off('change', _this3.callbacks[query.internalId]);
+
+            delete _this3.queries[key];
+            delete _this3.callbacks[query.internalId];
+          }
+        });
+
+        // Update existing queries / Create new queries
+        Object.keys(queryBuilders).forEach(function (key) {
+          var query = _this3.queries[key];
+          var builder = queryBuilders[key];
+
+          if (query) {
+            query.update(builder.build());
+          } else {
+            var newQuery = _this3.client.createQuery(builder);
+
+            _this3.queries[key] = newQuery;
+            _this3.callbacks[newQuery.internalId] = function () {
+              _this3._onQueryChange(key, newQuery.data);
+            };
+
+            newQuery.on('change', _this3.callbacks[newQuery.internalId]);
+          }
+        });
+
+        _this3.setState({
+          queryParams: queryParams
+        }, callback);
+      };
+    }, _temp
+  );
+};

--- a/build/components/connectReduxQuery.js
+++ b/build/components/connectReduxQuery.js
@@ -18,8 +18,6 @@ var _connectQueryParent3 = _interopRequireDefault(_connectQueryParent2);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
-
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
 function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
@@ -59,6 +57,8 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 exports.default = function () {
   var getInitialQueryParams = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
   var getQueries = arguments[1];
+  var dispatchSetQueryResults = arguments[2];
+  var dispatchUpdateQueryResults = arguments[3];
   return (
     /**
      * Takes a Component, and wraps it with a QueryContainer (makes the
@@ -80,7 +80,7 @@ exports.default = function () {
          * @extends {react.Component}
          */
         function (_connectQueryParent) {
-          _inherits(QueryContainer, _connectQueryParent);
+          _inherits(ReduxQueryContainer, _connectQueryParent);
 
           /**
            * Call getQueries to get our QueryBuilder instances, and populate
@@ -89,19 +89,19 @@ exports.default = function () {
            *
            * @method constructor
            */
-          function QueryContainer(props, context) {
-            _classCallCheck(this, QueryContainer);
+          function ReduxQueryContainer(props, context) {
+            _classCallCheck(this, ReduxQueryContainer);
 
-            var _this = _possibleConstructorReturn(this, (QueryContainer.__proto__ || Object.getPrototypeOf(QueryContainer)).call(this, props, context));
+            var _this = _possibleConstructorReturn(this, (ReduxQueryContainer.__proto__ || Object.getPrototypeOf(ReduxQueryContainer)).call(this, props, context));
 
             _this._onQueryChange = function (queryName, newResults) {
-              _this.setState({
-                queryResults: _extends({}, _this.state.queryResults, _defineProperty({}, queryName, newResults))
-              });
+              dispatchUpdateQueryResults(queryName, newResults);
             };
 
+            dispatchSetQueryResults(_this.queryResults);
+
             _this.state = {
-              queryResults: _this.queryResults,
+              // queryResults: this.queryResults,
               queryParams: _this.queryParams
             };
             return _this;
@@ -109,10 +109,12 @@ exports.default = function () {
 
           /**
            * Any time the Query's data changes,
+           * dispatch using dispatchUpdateQueryResults
+           * with the new results.
            * update this.state.queryResults[queryName]
-           * with the new results.  Setting state will cause
-           * the render method to pass the updated query data
-           * to its ComposedComponent.
+           * with the new results.  Updating the Redux store
+           * will cause all connected components to receive
+           * the updated query data.
            *
            * @method _onQueryChange
            * @param  {string} queryName    - Name of the query (name comes from keys returned by getQueries())
@@ -120,7 +122,7 @@ exports.default = function () {
            */
 
 
-          _createClass(QueryContainer, [{
+          _createClass(ReduxQueryContainer, [{
             key: 'render',
 
 
@@ -134,9 +136,7 @@ exports.default = function () {
             value: function render() {
               var _this2 = this;
 
-              var _state = this.state,
-                  queryParams = _state.queryParams,
-                  queryResults = _state.queryResults;
+              var queryParams = this.state.queryParams;
 
 
               var queryIds = {};
@@ -144,19 +144,19 @@ exports.default = function () {
                 queryIds[key] = _this2.queries[key].id;
               });
 
-              var passedProps = _extends({}, queryResults, {
+              var passedProps = {
                 query: {
                   queryParams: queryParams,
                   setQueryParams: this.setQueryParams,
                   queryIds: queryIds
                 }
-              });
+              };
 
               return _react2.default.createElement(ComposedComponent, _extends({}, this.props, passedProps));
             }
           }]);
 
-          return QueryContainer;
+          return ReduxQueryContainer;
         }((0, _connectQueryParent3.default)(getInitialQueryParams, getQueries))
       );
     }

--- a/build/components/connectTypingIndicator.js
+++ b/build/components/connectTypingIndicator.js
@@ -1,0 +1,136 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; } /**
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                * The createTypingIndicator module creates a Wrapped Component;
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                * it takes in a Client (typically via the LayerProvider)
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                * and a conversationId (the Conversation the user is currently viewing)
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                * and adds `typing` and `paused` properties to the Wrapped Component
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                * allowing for the component to render a typing indicator.
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                */
+
+
+/**
+ * Exports a function that takes as input a Component to wrap and returns a new Component.
+ * The new Component takes as input a client and conversationId, and adds `typing` and `paused`
+ * properties to the component that was passed as input, allowing for the component to render a typing indicator.
+ *
+ * @method connectTypingIndicator
+ * @return {Function}      Call this function to create a wrapped component which can be
+ *                         be rendered and which passes typing indicator data to its child.
+ */
+exports.default = function () {
+  return (
+    /**
+     * Takes a Component, and wraps it with a TypingIndicatorContainer (makes the
+     * input Component a child Component of the TypingIndicatorContainer) and
+     * passes in typing indicator data to the wrapped Component in the form of properties.
+     *
+     * @method
+     * @param  {Component} ComposedComponent   The Component to wrap
+     * @return {TypingIndicatorContainer}      A Component that wraps the specified Component
+     */
+    function (ComposedComponent) {
+      var _class, _temp;
+
+      return (
+        /**
+         * The TypingIndicatorContainer listens for typing indicator events from the client that
+         * relate to the current conversation, and passes typing and paused properties into its child
+         * component.
+         *
+         * @class TypingIndicatorContainer
+         * @extends {react.Component}
+         */
+        _temp = _class = function (_Component) {
+          _inherits(TypingIndicatorContainer, _Component);
+
+          function TypingIndicatorContainer(props, context) {
+            _classCallCheck(this, TypingIndicatorContainer);
+
+            var _this = _possibleConstructorReturn(this, (TypingIndicatorContainer.__proto__ || Object.getPrototypeOf(TypingIndicatorContainer)).call(this, props, context));
+
+            _this.onTypingIndicatorChange = function (_ref) {
+              var conversationId = _ref.conversationId,
+                  typing = _ref.typing,
+                  paused = _ref.paused;
+
+              if (conversationId === _this.props.conversationId) {
+                _this.setState({
+                  typing: typing,
+                  paused: paused
+                });
+              }
+            };
+
+            _this.client = props.client || context.client;
+
+            _this.state = {
+              typing: [],
+              paused: []
+            };
+            return _this;
+          }
+
+          // Necessary in order to grab client out of the context.
+          // TODO: May want to rename to layerClient to avoid conflicts.
+
+
+          _createClass(TypingIndicatorContainer, [{
+            key: 'componentWillMount',
+            value: function componentWillMount() {
+              this.client.on('typing-indicator-change', this.onTypingIndicatorChange);
+            }
+          }, {
+            key: 'componentWillReceiveProps',
+            value: function componentWillReceiveProps(nextProps) {
+              if (this.props.conversationId !== nextProps.conversationId) {
+                this.setState({
+                  typing: [],
+                  paused: []
+                });
+              }
+            }
+          }, {
+            key: 'render',
+            value: function render() {
+              return _react2.default.createElement(ComposedComponent, _extends({}, this.props, this.state));
+            }
+          }, {
+            key: 'componentWillUnmount',
+            value: function componentWillUnmount() {
+              this.client.off('typing-indicator-change', this.onTypingIndicatorChange);
+            }
+          }]);
+
+          return TypingIndicatorContainer;
+        }(_react.Component), _class.propTypes = {
+          client: _propTypes2.default.object,
+          conversationId: _propTypes2.default.string }, _class.contextTypes = {
+          client: _propTypes2.default.object
+        }, _temp
+      );
+    }
+  );
+};

--- a/build/index.js
+++ b/build/index.js
@@ -22,6 +22,15 @@ Object.defineProperty(exports, 'connectQuery', {
   }
 });
 
+var _connectReduxQuery = require('./components/connectReduxQuery');
+
+Object.defineProperty(exports, 'connectReduxQuery', {
+  enumerable: true,
+  get: function get() {
+    return _interopRequireDefault(_connectReduxQuery).default;
+  }
+});
+
 var _connectTypingIndicator = require('./components/connectTypingIndicator');
 
 Object.defineProperty(exports, 'connectTypingIndicator', {

--- a/build/index.js
+++ b/build/index.js
@@ -1,0 +1,34 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _LayerProvider = require('./components/LayerProvider');
+
+Object.defineProperty(exports, 'LayerProvider', {
+  enumerable: true,
+  get: function get() {
+    return _interopRequireDefault(_LayerProvider).default;
+  }
+});
+
+var _connectQuery = require('./components/connectQuery');
+
+Object.defineProperty(exports, 'connectQuery', {
+  enumerable: true,
+  get: function get() {
+    return _interopRequireDefault(_connectQuery).default;
+  }
+});
+
+var _connectTypingIndicator = require('./components/connectTypingIndicator');
+
+Object.defineProperty(exports, 'connectTypingIndicator', {
+  enumerable: true,
+  get: function get() {
+    return _interopRequireDefault(_connectTypingIndicator).default;
+  }
+});
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }

--- a/src/components/connectQuery.js
+++ b/src/components/connectQuery.js
@@ -69,6 +69,26 @@ export default (getInitialQueryParams = {}, getQueries) =>
       }
 
       /**
+       * Any time the Query's data changes,
+       * update this.state.queryResults[queryName]
+       * with the new results.  Setting state will cause
+       * the render method to pass the updated query data
+       * to its ComposedComponent.
+       *
+       * @method _onQueryChange
+       * @param  {string} queryName    - Name of the query (name comes from keys returned by getQueries())
+       * @param  {Object[]} newResults - Array of query results
+       */
+      _onQueryChange = (queryName, newResults) => {
+        this.setState({
+          queryResults: {
+            ...this.state.queryResults,
+            [queryName]: newResults,
+          },
+        });
+      }
+
+      /**
        * Pass any properties provided to the QueryContainer
        * to its child container, along with the query results,
        * query parameters, and a setQueryParams function.

--- a/src/components/connectQueryParent.js
+++ b/src/components/connectQueryParent.js
@@ -138,26 +138,6 @@ export default (getInitialQueryParams = {}, getQueries) =>
       }, callback);
     }
 
-    /**
-     * Any time the Query's data changes,
-     * update this.state.queryResults[queryName]
-     * with the new results.  Setting state will cause
-     * the render method to pass the updated query data
-     * to its ComposedComponent.
-     *
-     * @method _onQueryChange
-     * @param  {string} queryName    - Name of the query (name comes from keys returned by getQueries())
-     * @param  {Object[]} newResults - Array of query results
-     */
-    _onQueryChange = (queryName, newResults) => {
-      this.setState({
-        queryResults: {
-          ...this.state.queryResults,
-          [queryName]: newResults,
-        },
-      });
-    }
-
     componentWillUnmount() {
       // When the component unmounts, unsubscribe from all event listeners.
       Object.keys(this.queries).forEach((key) => {

--- a/src/components/connectQueryParent.js
+++ b/src/components/connectQueryParent.js
@@ -1,0 +1,169 @@
+import { Component } from 'react';
+import PropTypes from 'prop-types';
+
+/**
+ * Provides base Layer query functionality.
+ * Intended to be subclassed, does not provide a Render method.
+ * Built to abstract functionality to a higher level, so different
+ * store implementations can be used (see connectQuery and connectReduxQuery).
+ * See below for an example usage.
+ *
+      class QueryContainer extends connectQueryParent(getInitialQueryParams, getQueries)
+ *
+ * @method connectQuery
+ * @param  {Object|Function} getInitialQueryParams   Initial properties for all queries
+ * @param  {Function} getQueries          A function that returns a hash of QueryBuilders
+ * @param {Object} getQueries.props       All properties passed in from the parent of this component
+ * @param {Object} getQueries.queryParams Initial property values as specified by getInitialQueryParams
+ * @param {Object} getQueries.return      A hash of Query instances
+ * @return {Function}                     Call this function to create a parent component to extend Query
+ *                                        subclasses
+ */
+export default (getInitialQueryParams = {}, getQueries) =>
+  /**
+   * A Component which manages a set of Queries and passes the output
+   * of those queries into its child component.
+   *
+   * @class QueryContainer
+   * @extends {react.Component}
+   */
+  class Query extends Component {
+    static propTypes = {
+      client: PropTypes.object,
+    }
+
+    // Necessary in order to grab client out of the context.
+    // TODO: May want to rename to layerClient to avoid conflicts.
+    static contextTypes = {
+      client: PropTypes.object,
+    }
+
+    /**
+     * Call getQueries to get our QueryBuilder instances, and populate
+     * state with the Query Parameters and Query Results (initially results
+     * are all [])
+     *
+     * @method constructor
+     */
+    constructor(props, context) {
+      super(props, context);
+
+      this.client = props.client || context.client;
+      this.queries = {};
+      this.callbacks = {};
+
+      this.queryParams = (typeof getInitialQueryParams === 'function')
+        ? getInitialQueryParams(props)
+        : getInitialQueryParams;
+
+      this.queryBuilders = getQueries(props, this.queryParams);
+
+      // Set initial queryResults to empty arrays.
+      this.queryResults = Object.keys(this.queryBuilders).reduce((obj, key) => ({
+        ...obj,
+        [key]: [],
+      }), {});
+    }
+
+    /**
+     * On mounting (and once the client is ready) call _updateQueries
+     */
+    componentWillMount() {
+      this.client.on('ready', this._onClientReady);
+
+      if (this.client.isReady) {
+        this._updateQueries(this.props, this.state.queryParams);
+      }
+    }
+
+    _onClientReady = () => {
+      this._updateQueries(this.props, this.state.queryParams);
+    }
+
+    setQueryParams = (nextQueryParams, callback) => {
+      this._updateQueries(this.props, nextQueryParams, callback);
+    }
+
+    componentWillReceiveProps(nextProps) {
+      this._updateQueries(nextProps, this.state.queryParams);
+    }
+
+    /**
+     * Generate the this.queries object to contain
+     * layer.Query instances based on the getQueries()
+     * QueryBuilders.  If the query already exists, update
+     * it rather than replace it.
+     *
+     * @method _updateQueries
+     * @private
+     * @param  {Object}   props       Component properties
+     * @param  {Object}   queryParams Query properties
+     * @param  {Function} callback
+     */
+    _updateQueries = (props, queryParams, callback) => {
+      const queryBuilders = getQueries(props, queryParams);
+
+      // Remove any queries that no longer exist
+      Object.keys(this.queries).forEach((key) => {
+        if (!queryBuilders[key]) {
+          const query = this.queries[key];
+          query.off('change', this.callbacks[query.internalId]);
+
+          delete this.queries[key];
+          delete this.callbacks[query.internalId];
+        }
+      });
+
+      // Update existing queries / Create new queries
+      Object.keys(queryBuilders).forEach((key) => {
+        const query = this.queries[key];
+        const builder = queryBuilders[key];
+
+        if (query) {
+          query.update(builder.build());
+        } else {
+          const newQuery = this.client.createQuery(builder);
+
+          this.queries[key] = newQuery;
+          this.callbacks[newQuery.internalId] = () => {
+            this._onQueryChange(key, newQuery.data);
+          };
+
+          newQuery.on('change', this.callbacks[newQuery.internalId]);
+        }
+      });
+
+      this.setState({
+        queryParams,
+      }, callback);
+    }
+
+    /**
+     * Any time the Query's data changes,
+     * update this.state.queryResults[queryName]
+     * with the new results.  Setting state will cause
+     * the render method to pass the updated query data
+     * to its ComposedComponent.
+     *
+     * @method _onQueryChange
+     * @param  {string} queryName    - Name of the query (name comes from keys returned by getQueries())
+     * @param  {Object[]} newResults - Array of query results
+     */
+    _onQueryChange = (queryName, newResults) => {
+      this.setState({
+        queryResults: {
+          ...this.state.queryResults,
+          [queryName]: newResults,
+        },
+      });
+    }
+
+    componentWillUnmount() {
+      // When the component unmounts, unsubscribe from all event listeners.
+      Object.keys(this.queries).forEach((key) => {
+        const query = this.queries[key];
+        query.off('change', this.callbacks[query.internalId]);
+        this.client.off('ready', this._onClientReady, this);
+      });
+    }
+  };

--- a/src/components/connectReduxQuery.js
+++ b/src/components/connectReduxQuery.js
@@ -1,0 +1,115 @@
+import React from 'react';
+
+import connectQueryParent from './connectQueryParent';
+
+/**
+ * Connects your Queries to your React Component properties.
+ * In the example below, a ConversationList is passed in,
+ * and a ConversationListContainer that contains a child of ConversationList
+ * and which provides ConversationList with properties provided
+ * by the queries.
+ *
+      function getInitialQueryParams (props) {
+        return {
+          paginationWindow: props.startingPaginationWindow || 100
+        };
+      }
+
+      function getQueries(props, queryParams) {
+        return {
+          conversations: QueryBuilder.conversations().paginationWindow(queryParams.paginationWindow)
+        };
+      }
+
+      var ConversationListContainer = connectQuery(getInitialQueryParams, getQueries)(ConversationList);
+ *
+ * @method connectQuery
+ * @param  {Object|Function} getInitialQueryParams   Initial properties for all queries
+ * @param  {Function} getQueries          A function that returns a hash of QueryBuilders
+ * @param {Object} getQueries.props       All properties passed in from the parent of this component
+ * @param {Object} getQueries.queryParams Initial property values as specified by getInitialQueryParams
+ * @param {Object} getQueries.return      A hash of Query instances
+ * @return {Function}                     Call this function to create a wrapped component which can be
+ *                                        be rendered and which passes query data to your component.
+ */
+export default (getInitialQueryParams = {}, getQueries, dispatchSetQueryResults, dispatchUpdateQueryResults) =>
+  /**
+   * Takes a Component, and wraps it with a QueryContainer (makes the
+   * input Component a child Component of the QueryContainer) and
+   * passes in Query data to the wrapped Component in the form of properties.
+   * Note that the property names will match the keys returned by getQueries().
+   *
+   * @method
+   * @param  {Component} ComposedComponent   The Component to wrap
+   * @return {QueryContainer}                A Component that wraps the specified Component
+   */
+  (ComposedComponent) =>
+    /**
+     * A Component which manages a set of Queries and passes the output
+     * of those queries into its child component.
+     *
+     * @class QueryContainer
+     * @extends {react.Component}
+     */
+    class ReduxQueryContainer extends connectQueryParent(getInitialQueryParams, getQueries) {
+      /**
+       * Call getQueries to get our QueryBuilder instances, and populate
+       * state with the Query Parameters and Query Results (initially results
+       * are all [])
+       *
+       * @method constructor
+       */
+      constructor(props, context) {
+        super(props, context);
+
+        dispatchSetQueryResults(this.queryResults);
+
+        this.state = {
+          // queryResults: this.queryResults,
+          queryParams: this.queryParams,
+        };
+      }
+
+      /**
+       * Any time the Query's data changes,
+       * dispatch using dispatchUpdateQueryResults
+       * with the new results.
+       * update this.state.queryResults[queryName]
+       * with the new results.  Updating the Redux store
+       * will cause all connected components to receive
+       * the updated query data.
+       *
+       * @method _onQueryChange
+       * @param  {string} queryName    - Name of the query (name comes from keys returned by getQueries())
+       * @param  {Object[]} newResults - Array of query results
+       */
+      _onQueryChange = (queryName, newResults) => {
+        dispatchUpdateQueryResults(queryName, newResults);
+      }
+
+      /**
+       * Pass any properties provided to the QueryContainer
+       * to its child container, along with the query results,
+       * query parameters, and a setQueryParams function.
+       *
+       * @method render
+       */
+      render() {
+        const { queryParams } = this.state;
+
+        const queryIds = {};
+        Object.keys(this.queries).forEach((key) => {
+          queryIds[key] = this.queries[key].id;
+        });
+
+        const passedProps = {
+          query: {
+            queryParams,
+            setQueryParams: this.setQueryParams,
+            queryIds,
+          },
+        };
+
+        return <ComposedComponent {...this.props} {...passedProps} />;
+      }
+    };

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
 export { default as LayerProvider } from './components/LayerProvider';
 export { default as connectQuery } from './components/connectQuery';
+export { default as connectReduxQuery } from './components/connectReduxQuery';
 export { default as connectTypingIndicator } from './components/connectTypingIndicator';


### PR DESCRIPTION
This pull request adds support for Redux by adding `connectQueryParent.js` and `connectReduxQuery.js`.

Note this pull request is not final and should not yet be merged into `layerhq/layer-react`. It serves as a starting point for discussion on supporting a wider variety of use cases.

Also note that components from `build/` have temporarily been added to the repository such that `npm install git+https://git@github.com/airyhq/layer-react.git` works as intended.

Developed in collaboration with @guttermouth.

## connectQueryParent.js

`connectQueryParent` is a React [higher-order component](https://reactjs.org/docs/higher-order-components.html) that provides base Layer query functionality. It is intended to be subclassed, and does not provide a render method.

`connectQueryParent` allows different state implementations to be used (see `connectQuery.js` and `connectReduxQuery.js`). 

### Usage

```
(getInitialQueryParams = {}, getQueries) =>
  (ComposedComponent) =>
    class QueryReduxContainer extends connectQueryParent(getInitialQueryParams, getQueries)
    ...
```

## connectReduxQuery.js

A dispatching implementation of updating the state of `queryResults`. Takes additional arguments `dispatchSetQueryResults` and `dispatchUpdateQueryResults`, called when setting initial query results and updating query results, respectively. Note this doesn't necessarily need to be used with [Redux](https://redux.js.org/), and can be re-named to something more generic.

### Usage

```
class ConversationList extends Component
...
const ConversationListContainer = connectReduxQuery({}, getQueries,
  (queryResults) => store.dispatch(conversationActions.setQueryResults(queryResults)),
  (queryName, newResults) => store.dispatch(conversationActions.updateQueryResults(queryName, newResults))
)(ConversationList)
```

### Usage as ES6 Decorator

```
@connectReduxQuery({}, getQueries,
  (queryResults) => store.dispatch(messengerActions.setQueryResults(queryResults)),
  (queryName, newResults) => store.dispatch(messengerActions.updateQueryResults(queryName, newResults))
)
export class ConversationListContainer extends Component
...
```